### PR TITLE
Support DAO ACK

### DIFF
--- a/src/data_collector/rpl_collector.c
+++ b/src/data_collector/rpl_collector.c
@@ -249,6 +249,22 @@ rpl_collector_parse_dao(packet_info_t pkt_info,
 }
 
 void
+rpl_collector_parse_dao_ack(packet_info_t pkt_info,
+                            rpl_dao_ack_t * dao_ack)
+{
+    di_node_t *node = NULL;
+    di_node_ref_t node_ref;
+    bool node_created = false;
+
+    node_ref_init(&node_ref, pkt_info.src_wpan_address);
+    node =
+      rpldata_get_node(&node_ref, HVM_CreateIfNonExistant, &node_created);
+    node_add_packet_count(node, 1);
+    node_set_ip(node, pkt_info.src_ip_address);
+    node_update_from_dao_ack(node, dao_ack);
+}
+
+void
 rpl_collector_parse_dis(packet_info_t pkt_info,
                         rpl_dis_opt_info_req_t * request)
 {

--- a/src/data_collector/rpl_collector.h
+++ b/src/data_collector/rpl_collector.h
@@ -43,6 +43,8 @@ void rpl_collector_parse_dio(packet_info_t pkt_info, rpl_dio_t * dio,
 void rpl_collector_parse_dao(packet_info_t pkt_info, rpl_dao_t * dao,
                              rpl_dao_opt_target_t * target,
                              rpl_dao_opt_transit_t * transit);
+void rpl_collector_parse_dao_ack(packet_info_t pkt_info,
+                                 rpl_dao_ack_t * dao_ack);
 void rpl_collector_parse_dis(packet_info_t pkt_info,
                              rpl_dis_opt_info_req_t * request);
 void rpl_collector_parse_data(packet_info_t pkt_info,

--- a/src/data_info/6lowpan_def.h
+++ b/src/data_info/6lowpan_def.h
@@ -55,6 +55,7 @@ typedef enum packet_type {
     PT_DIS,
     PT_DIO,
     PT_DAO,
+    PT_DAO_ACK,
     PT_UDP,
     PT_TCP,
     PT_IPv6_Unknown

--- a/src/data_info/node.c
+++ b/src/data_info/node.c
@@ -476,6 +476,12 @@ node_update_from_dao(di_node_t * node, const rpl_dao_t * dao,
 }
 
 void
+node_update_from_dao_ack(di_node_t * node, const rpl_dao_ack_t * dao_ack)
+{
+    node->rpl_statistics.dao_ack++;
+}
+
+void
 node_update_from_dodag_config(di_node_t * node,
                               const rpl_dodag_config_t * config,
                               const di_dodag_t * dodag)

--- a/src/data_info/node.h
+++ b/src/data_info/node.h
@@ -88,6 +88,8 @@ void node_update_from_hop_by_hop(di_node_t * node,
                                  const rpl_hop_by_hop_opt_t * hop_by_hop);
 void node_update_from_dao(di_node_t * node, const rpl_dao_t * dao,
                           const di_dodag_t * dodag);
+void node_update_from_dao_ack(di_node_t * node,
+                              const rpl_dao_ack_t * dao_ack);
 void node_update_from_dodag_config(di_node_t * node,
                                    const rpl_dodag_config_t * config,
                                    const di_dodag_t * dodag);

--- a/src/data_info/rpl_def.h
+++ b/src/data_info/rpl_def.h
@@ -259,6 +259,7 @@ typedef struct rpl_statistics {
     int dis;
     int dio;
     int dao;
+    int dao_ack;
 } rpl_statistics_t;
 
 typedef struct rpl_statistics_delta {
@@ -270,6 +271,7 @@ typedef struct rpl_statistics_delta {
     int dis;
     int dio;
     int dao;
+    int dao_ack;
 } rpl_statistics_delta_t;
 
 typedef struct rpl_errors {

--- a/src/packet_parsers/rpl_parser.c
+++ b/src/packet_parsers/rpl_parser.c
@@ -97,6 +97,10 @@ typedef struct rpl_packet_dao {
     rpl_dao_opt_transit_t transit;
 } rpl_packet_dao_t;
 
+typedef struct rpl_packet_dao_ack {
+    rpl_dao_ack_t dao_ack;
+} rpl_packet_dao_ack_t;
+
 typedef struct rpl_packet_data {
     bool has_hop_info;
     rpl_hop_by_hop_opt_t hop_info;
@@ -110,6 +114,7 @@ typedef struct rpl_packet_content {
         rpl_packet_dis_t dis;
         rpl_packet_dio_t dio;
         rpl_packet_dao_t dao;
+        rpl_packet_dao_ack_t dao_ack;
         rpl_packet_data_t data;
     };
 } rpl_packet_content_t;
@@ -292,6 +297,10 @@ rpl_parser_parse_field(const char *nameStr, const char *showStr,
             current_packet.pkt_info.type = PT_DAO;
             break;
 
+        case ICMPV6_RPL_CODE_DAO_ACK:
+            current_packet.pkt_info.type = PT_DAO_ACK;
+            break;
+
         default:
             fprintf(stderr, "Unsupported RPL packet code: %lld\n",
                     valueInt);
@@ -463,6 +472,18 @@ rpl_parser_parse_field(const char *nameStr, const char *showStr,
             if(option_check)
                 current_packet.dao.has_transit = true;
             break;
+
+        case PT_DAO_ACK:
+            if(!strcmp(nameStr, "icmpv6.rpl.daoack.instance"))
+                current_packet.dao_ack.dao_ack.rpl_instance_id = valueInt;
+            else if(!strcmp(nameStr, "icmpv6.rpl.daoack.flag.d"))
+                current_packet.dao_ack.dao_ack.dodagid_present = valueInt;
+            else if(!strcmp(nameStr, "icmpv6.rpl.daoack.sequence"))
+                current_packet.dao_ack.dao_ack.dao_sequence = valueInt;
+            else if(!strcmp(nameStr, "icmpv6.rpl.daoack.status"))
+                current_packet.dao_ack.dao_ack.status = valueInt;
+            else if(!strcmp(nameStr, "icmpv6.rpl.daoack.dodagid"))
+                inet_pton(AF_INET6, showStr, &current_packet.dao_ack.dao_ack.dodagid);
 
         default:
             //Transit option

--- a/src/packet_parsers/rpl_parser.c
+++ b/src/packet_parsers/rpl_parser.c
@@ -560,6 +560,11 @@ rpl_parser_end_packet()
                                     transit : NULL);
             break;
 
+        case PT_DAO_ACK:
+            rpl_collector_parse_dao_ack(current_packet.pkt_info,
+                                        &current_packet.dao_ack.dao_ack);
+            break;
+
         case PT_RPL_Unknown:
             fprintf(stderr, "Warning: invalid RPL packet\n");
             break;


### PR DESCRIPTION
foren6-analyzer outputs 'Unsupported RPL packet code: 3' when it gets a DAO ACK.

This changes enable it to handle DAO ACK packets and to count how many DAO ACKs are sent per node. 
