### PR TITLE
Change ifinstance.ethernet to generic encap_dlt

### DIFF
--- a/src/interface_reader/interfaces_mgr.c
+++ b/src/interface_reader/interfaces_mgr.c
@@ -219,7 +219,7 @@ interfacemgr_create_handle(const char *target)
 
     handle->last_packets = hash_create(sizeof(struct packet_data), NULL);
     handle->first_packet = true;
-    handle->ethernet = false;
+    handle->encap_dlt = -1;
     handle->fcs = true;
     handle->target = strdup(target);
 

--- a/src/interface_reader/interfaces_mgr.h
+++ b/src/interface_reader/interfaces_mgr.h
@@ -45,7 +45,7 @@ typedef struct ifinstance {
     struct ifinstance *parent;
     hash_container_ptr last_packets;
     bool first_packet;
-    bool ethernet;
+    int encap_dlt;
     bool fcs;
 
     //for lists


### PR DESCRIPTION
This way, more encapsulation types can be supported (e.g. Linux "cooked")