### PR TITLE
add INTERFACE_TARGET

### DIFF
--- a/src/interface_reader/interfaces_mgr.h
+++ b/src/interface_reader/interfaces_mgr.h
@@ -66,6 +66,7 @@ typedef struct interface {
 #define INTERFACE_DEVICE 0x1
 #define INTERFACE_CHANNEL 0x2
 #define INTERFACE_BAUDRATE 0x4
+#define INTERFACE_TARGET 0x8
 
 typedef void (*interface_enum_function_t) (const char *interface_name);
 typedef int (*interface_version_function_t) ();


### PR DESCRIPTION
This adds an `INTERFACE_TARGET` flag to allow editing the device path (for entering an hostname or IP address) but without allowing to select a device.

needed for https://github.com/cetic/foren6-capture/pull/2